### PR TITLE
Implement fork

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,12 +97,13 @@ pub fn lib_main() {
     {
         let mut env_table = env::env_table();
         env::env_create_for_hello(&mut env_table);
-        env::env_create_for_yield(&mut env_table);
-        env::env_create_for_yield(&mut env_table);
-        env::env_create_for_yield(&mut env_table);
+        // env::env_create_for_yield(&mut env_table);
+        // env::env_create_for_yield(&mut env_table);
+        // env::env_create_for_yield(&mut env_table);
+        env::env_create_for_forktest(&mut env_table);
     }
 
-    unsafe { mp::boot_aps() };
+    mp::boot_aps();
 
     sched::sched_yield();
 }

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -14,6 +14,7 @@ mod consts {
     pub(crate) static SYS_EXIT: u32 = 2;
     pub(crate) static SYS_YIELD: u32 = 3;
     pub(crate) static SYS_GET_ENV_ID: u32 = 4;
+    pub(crate) static SYS_FORK: u32 = 5;
 }
 
 fn sys_cputs(s: &str) {
@@ -27,6 +28,11 @@ fn sys_yield() {
 fn sys_get_env_id() -> EnvId {
     let cur_env = env::cur_env().unwrap();
     cur_env.get_env_id()
+}
+
+fn sys_fork() -> EnvId {
+    let cur_env = env::cur_env_mut().unwrap();
+    env::fork(cur_env)
 }
 
 /// Dispatched to the correct kernel function, passing the arguments.
@@ -63,6 +69,9 @@ pub(crate) unsafe fn syscall(
         0
     } else if syscall_no == SYS_GET_ENV_ID {
         let env_id = sys_get_env_id();
+        env_id.0 as i32
+    } else if syscall_no == SYS_FORK {
+        let env_id = sys_fork();
         env_id.0 as i32
     } else {
         panic!("unknown syscall");

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -300,7 +300,7 @@ unsafe fn print_trapframe(tf: &Trapframe) {
     // If this trap was a page fault that just happened
     // (so %cr2 is meaningful), print the faulting linear address.
     if Some(tf) == LAST_TF.as_ref() && tf.tf_trapno == T_PGFLT {
-        println!("  cr2  0x{:08x}", x86::rcr2());
+        println!("  cr2   0x{:08x}", x86::rcr2());
     }
     print!("  err   0x{:08x}", tf.tf_err);
     // For page faults, print decoded fault error code:
@@ -311,7 +311,7 @@ unsafe fn print_trapframe(tf: &Trapframe) {
         println!(
             " [{}, {}, {}]",
             if tf.tf_err & 4 > 0 { "user" } else { "kernel" },
-            if tf.tf_err & 2 > 0 { "write" } else { " read" },
+            if tf.tf_err & 2 > 0 { "write" } else { "read" },
             if tf.tf_err & 1 > 0 {
                 "protection"
             } else {
@@ -344,8 +344,8 @@ unsafe fn print_regs(regs: &PushRegs) {
 fn trap_dispatch(tf: &mut Trapframe) {
     // Handle processor exceptions.
     match tf.tf_trapno {
-        T_PGFLT => unimplemented!(),
-        T_BRKPT => unimplemented!(),
+        // T_PGFLT => unimplemented!(),
+        // T_BRKPT => unimplemented!(),
         T_SYSCALL => unsafe {
             let ret = syscall::syscall(
                 tf.tf_regs.reg_eax,

--- a/user/forktest.c
+++ b/user/forktest.c
@@ -1,0 +1,11 @@
+#include "user.h"
+
+void umain(int argc, char **argv) {
+    int i;
+    int child = sys_fork();
+
+    for (i = 0; i < (child ? 10 : 20); i++) {
+        printf("%d: I am the %s!\n", i, child ? "parent" : "child");
+        sys_yield();
+    }
+}

--- a/user/lib/syscall.c
+++ b/user/lib/syscall.c
@@ -11,6 +11,7 @@
 #define SYS_EXIT 2
 #define SYS_YIELD 3
 #define SYS_GET_ENV_ID 4
+#define SYS_FORK 5
 
 static inline int syscall(int num, int a1, int a2, int a3, int a4, int a5) {
     int ret;
@@ -54,4 +55,8 @@ void sys_yield(void) {
 
 int sys_get_env_id(void) {
     return syscall(SYS_GET_ENV_ID, 0, 0, 0, 0, 0);
+}
+
+int sys_fork(void) {
+    return syscall(SYS_FORK, 0, 0, 0, 0, 0);
 }

--- a/user/module.mk
+++ b/user/module.mk
@@ -2,6 +2,7 @@ UPROGS += \
 	$(OBJDIR)/user/nop \
 	$(OBJDIR)/user/hello \
 	$(OBJDIR)/user/yield \
+	$(OBJDIR)/user/forktest \
 
 include user/lib/module.mk
 

--- a/user/user.h
+++ b/user/user.h
@@ -12,6 +12,7 @@ void sys_cputs(const char *s, int len);
 void sys_exit(int status);
 void sys_yield(void);
 int sys_get_env_id(void);
+int sys_fork(void);
 
 size_t strlen(const char *s);
 size_t strnlen(const char *s, size_t maxlen);


### PR DESCRIPTION
Implement fork.

The implementation is base on that of xv6, so it copies all allocated user memory when fork is called (not Copy-on-Write).