### PR TITLE
Add basic operations of IDE

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -1,0 +1,35 @@
+use crate::constants::*;
+use core::ptr::null_mut;
+
+pub(crate) mod consts {
+    // flags
+    pub(crate) const BUF_FLAGS_VALID: u32 = 0x2; // buffer has been read from disk
+    pub(crate) const BUF_FLAGS_DIRTY: u32 = 0x4; // buffer needs to be written to disk
+}
+
+pub(crate) struct Buf {
+    pub(crate) flags: u32,
+    pub(crate) dev: u32,
+    pub(crate) blockno: u32,
+    // lock: SleepLock,
+    pub(crate) refcnt: u32,
+    pub(crate) prev: *mut Buf, // LRU cache list
+    pub(crate) next: *mut Buf,
+    pub(crate) qnext: *mut Buf, // disk queue
+    pub(crate) data: [u8; BLK_SIZE],
+}
+
+impl Buf {
+    pub(crate) fn new() -> Buf {
+        Buf {
+            flags: 0,
+            dev: 0,
+            blockno: 0,
+            refcnt: 0,
+            prev: null_mut(),
+            next: null_mut(),
+            qnext: null_mut(),
+            data: [0; BLK_SIZE],
+        }
+    }
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,7 +4,7 @@ pub(crate) const KERN_BASE: u32 = 0xf0000000;
 pub(crate) const PGSIZE: u32 = 4096;
 pub(crate) const PGSHIFT: u32 = 12;
 
-// Page table/directory entry falgs
+// Page table/directory entry flags
 pub(crate) const PTE_PCD: u32 = 0x10; // Cache-disable if set
 pub(crate) const PTE_PWT: u32 = 0x8; // 1: Write-Through, 0: Write-Back
 pub(crate) const PTE_U: u32 = 0x4; // User
@@ -70,3 +70,8 @@ pub(crate) const FL_AC: u32 = 1 << 18; // Alignment Check
 pub(crate) const FL_VIF: u32 = 1 << 19; // Virtual Interrupt Flag
 pub(crate) const FL_VIP: u32 = 1 << 20; // Virtual Interrupt Pending
 pub(crate) const FL_ID: u32 = 1 << 21; // ID flag
+
+// file system
+pub(crate) const BLK_SIZE: usize = 512;
+pub(crate) const SECTOR_SIZE: usize = 512;
+pub(crate) const FS_SIZE: usize = 1000;

--- a/src/ide.rs
+++ b/src/ide.rs
@@ -1,0 +1,314 @@
+// Simple PIO-based (non-DMA) IDE driver code.
+// ref. [OSDev](https://wiki.osdev.org/PCI_IDE_Controller)
+// ref. [Spec](http://www.t13.org/Documents/UploadedDocuments/project/d0791r4c-ATA-1.pdf)
+// ref. [About Compatibility Mode](http://www.bswd.com/pciide.pdf)
+
+use crate::buf::consts::{BUF_FLAGS_DIRTY, BUF_FLAGS_VALID};
+use crate::buf::Buf;
+use crate::constants::*;
+use crate::pmap::VirtAddr;
+use crate::spinlock::Mutex;
+use crate::trap::consts::IRQ_IDE;
+use crate::{picirq, util, x86};
+use consts::*;
+use core::ptr::null_mut;
+
+mod consts {
+    // status
+    pub(crate) const SR_BSY: u8 = 0x80; // busy
+    pub(crate) const SR_DRDY: u8 = 0x40; // drive ready
+    pub(crate) const SR_DWF: u8 = 0x20; // drive write fault
+    pub(crate) const SR_ERR: u8 = 0x01; // error
+
+    pub(crate) const PRIMARY_COMMAND_BASE_REG: u16 = 0x1f0; // for sending command to drive or posting status from the drive
+    pub(crate) const PRIMARY_CONTROL_BASE_REG: u16 = 0x3f6; // for drive control and post alternate status
+
+    // register
+    // `PRIMARY_BASE_REG + reg` is a target port
+    pub(crate) const REG_DATA: u16 = 0x00; // Read-Write
+    pub(crate) const REG_ERROR: u16 = 0x01; // Read Only
+    pub(crate) const REG_FEATURES: u16 = 0x01; // Write Only
+    pub(crate) const REG_SECCOUNT0: u16 = 0x02; // Read-Write
+    pub(crate) const REG_LBA0: u16 = 0x03; // Read-Write
+    pub(crate) const REG_LBA1: u16 = 0x04; // Read-Write
+    pub(crate) const REG_LBA2: u16 = 0x05; // Read-Write
+    pub(crate) const REG_HDDEVSEL: u16 = 0x6; // Read-Write, used to select a drive in the channel.
+    pub(crate) const REG_COMMAND: u16 = 0x07; // Write Only
+    pub(crate) const REG_STATUS: u16 = 0x07; // Read Only
+
+    // Command codes
+    // See 9 Command Description in Spec
+    pub(crate) const IDE_CMD_READ: u8 = 0x20;
+    pub(crate) const IDE_CMD_WRITE: u8 = 0x30;
+    pub(crate) const IDE_CMD_RDMUL: u8 = 0xc4;
+    pub(crate) const IDE_CMD_WRMUL: u8 = 0xc5;
+}
+
+struct BufQueue {
+    head: *mut Buf,
+    len: usize,
+}
+
+unsafe impl Sync for BufQueue {}
+unsafe impl Send for BufQueue {}
+
+impl BufQueue {
+    const fn new() -> BufQueue {
+        BufQueue {
+            head: null_mut(),
+            len: 0,
+        }
+    }
+
+    fn size(&self) -> usize {
+        self.len
+    }
+
+    fn push(&mut self, b: *mut Buf) {
+        unsafe {
+            if self.head.is_null() {
+                self.head = b;
+            } else {
+                let mut prev = self.head;
+                while !(*prev).qnext.is_null() {
+                    prev = (*prev).qnext;
+                }
+                (*prev).qnext = b;
+            }
+            self.len += 1;
+        }
+    }
+
+    fn pop(&mut self) -> Option<*mut Buf> {
+        unsafe {
+            if self.head.is_null() {
+                None
+            } else {
+                let res = self.head;
+                self.head = (*self.head).qnext;
+                self.len -= 1;
+                Some(res)
+            }
+        }
+    }
+}
+
+static BUF_QUEUE: Mutex<BufQueue> = Mutex::new(BufQueue::new());
+
+/// Wait until disk to be ready.
+fn ide_wait_ready(check_error: bool) -> bool {
+    let mut r: u8;
+
+    loop {
+        // ref. 7.2.13 Status register in Spec
+        r = x86::inb(PRIMARY_COMMAND_BASE_REG + REG_STATUS);
+        if (r & (SR_BSY | SR_DRDY)) == SR_DRDY {
+            break;
+        }
+    }
+
+    !check_error || ((r & (SR_DWF | SR_ERR)) == 0)
+}
+
+/// Check whether Device 1 exists.
+/// (With qemu, it means that we have an option like `-drive file=fs.img,index=1,media=disk,format=raw`)
+fn ide_probe_disk1() -> bool {
+    // wait for Device 0 to be ready
+    if !ide_wait_ready(true) {
+        panic!("something wrong with ide");
+    }
+
+    // switch to Device 1
+    // ref. 7.2.8 Drive/head register in Spec
+    x86::outb(PRIMARY_COMMAND_BASE_REG + REG_HDDEVSEL, 0xe0 | (1 << 4));
+
+    // check whether Device 1 exists and get ready
+    let mut found: bool = false;
+    for _ in 0..1000 {
+        let r = x86::inb(PRIMARY_COMMAND_BASE_REG + REG_STATUS);
+        if r != 0 {
+            if r & (SR_BSY | SR_DWF | SR_ERR) == 0 {
+                found = true;
+                break;
+            }
+        }
+    }
+
+    // switch back to Device 0
+    x86::outb(PRIMARY_COMMAND_BASE_REG + REG_HDDEVSEL, 0xe0 | (0 << 4));
+
+    print!("Device 1 presence: ");
+    if found {
+        println!("yes");
+    } else {
+        println!("no");
+    }
+    found
+}
+
+fn ide_start(b: &Buf) {
+    if b.blockno >= (FS_SIZE as u32) {
+        panic!("ide_start: incorrect blockno");
+    }
+
+    let sector_per_block = (BLK_SIZE / SECTOR_SIZE) as u32;
+    let sector = b.blockno * sector_per_block;
+    let read_cmd = if sector_per_block == 1 {
+        IDE_CMD_READ
+    } else {
+        IDE_CMD_RDMUL
+    };
+    let write_cmd = if sector_per_block == 1 {
+        IDE_CMD_WRITE
+    } else {
+        IDE_CMD_WRMUL
+    };
+
+    if sector_per_block > 7 {
+        panic!("ide_start: illegal sector per block");
+    }
+
+    if !ide_wait_ready(true) {
+        panic!("ide_start: something bad occurred.")
+    }
+
+    // This is Device Control Register? (7.2.6 in Spec).
+    // This enables to generate interrupt?
+    // This exists only in xv6 not in JOS, so may be not mandatory.
+    x86::outb(PRIMARY_CONTROL_BASE_REG, 0); // generate interrupt
+
+    // This register contains the number of sectors of data requested to be transferred
+    // on a read or write operation between the host and the drive.
+    // See 7.2 in Spec.
+    x86::outb(
+        PRIMARY_COMMAND_BASE_REG + REG_SECCOUNT0,
+        sector_per_block as u8,
+    ); // number of sectors
+
+    // This register contains the starting sector number for any disk data access
+    // for the subsequent command.
+    // As we set up in `ide_probe_disk1`, addressing is based on LBA not CHS.
+    // See 7.2 in Spec.
+    x86::outb(PRIMARY_COMMAND_BASE_REG + REG_LBA0, (sector & 0xff) as u8);
+    x86::outb(
+        PRIMARY_COMMAND_BASE_REG + REG_LBA1,
+        ((sector >> 8) & 0xff) as u8,
+    );
+    x86::outb(
+        PRIMARY_COMMAND_BASE_REG + REG_LBA2,
+        ((sector >> 16) & 0xff) as u8,
+    );
+    x86::outb(
+        PRIMARY_COMMAND_BASE_REG + REG_HDDEVSEL,
+        0xe0 | (((b.dev & 1) as u8) << 4) | (((sector >> 24) & 0x0f) as u8),
+    );
+
+    if b.flags & BUF_FLAGS_DIRTY != 0 {
+        // This register contains the command code being sent to the drive.
+        // Command execution begins immediately after this register is written.
+        //
+        // The detail of write protocol is in 10.2 of Spec
+        x86::outb(PRIMARY_COMMAND_BASE_REG + REG_COMMAND, write_cmd);
+        x86::outsl(
+            PRIMARY_COMMAND_BASE_REG + REG_DATA,
+            b.data.as_ptr().cast::<u32>(),
+            BLK_SIZE / 4,
+        );
+    } else {
+        // The detail of read protocol is in 10.1 of Spec
+        x86::outb(PRIMARY_COMMAND_BASE_REG + REG_COMMAND, read_cmd);
+    }
+}
+
+/// Interrupt handler.
+pub(crate) fn ide_intr() {
+    // The first queued buffer is the active request.
+    let mut queue = BUF_QUEUE.lock();
+
+    if let Some(b) = queue.pop() {
+        let b = unsafe { &mut *b };
+
+        if !ide_wait_ready(true) {
+            panic!("ide_intr: something bad occurred.");
+        }
+
+        // Read data if needed.
+        if b.flags & BUF_FLAGS_DIRTY == 0 {
+            x86::insl(
+                PRIMARY_COMMAND_BASE_REG + REG_DATA,
+                b.data.as_mut_ptr().cast::<u32>(),
+                BLK_SIZE / 4,
+            );
+        }
+
+        b.flags |= BUF_FLAGS_VALID;
+        b.flags &= !BUF_FLAGS_DIRTY;
+
+        // Wake process waiting for this buf.
+        // wakeup(b);
+
+        // Stat disk on next buf in queue
+        if let Some(next_b) = queue.pop() {
+            let next_b = unsafe { &mut *next_b };
+            ide_start(next_b);
+        }
+    }
+}
+
+/// Sync buf with disk.
+/// If B_DIRTY is set, write buf to disk, clear B_DIRTY, set B_VALID.
+/// Else if B_VALID is not set, read buf from disk, set B_VALID.
+pub(crate) fn ide_rw(b: *mut Buf) {
+    let b = unsafe { &mut *b };
+
+    if (b.flags & (BUF_FLAGS_VALID | BUF_FLAGS_DIRTY)) == BUF_FLAGS_VALID {
+        panic!("ide_rw: nothing to do");
+    }
+
+    {
+        let mut queue = BUF_QUEUE.lock();
+
+        // Append b to queue
+        b.qnext = null_mut();
+        queue.push(b);
+
+        // There is only one Buf, which is one just appended.
+        if queue.size() == 1 {
+            ide_start(b);
+        }
+    }
+
+    // Wait for request to finish.
+    while (b.flags & (BUF_FLAGS_VALID | BUF_FLAGS_DIRTY)) != BUF_FLAGS_VALID {
+        x86::sti();
+        // sleep(b, &idelock);
+        x86::cli();
+    }
+}
+
+pub(crate) fn ide_init() {
+    if !ide_probe_disk1() {
+        panic!("Device 1 must be available");
+    }
+
+    picirq::unmask_8259a(IRQ_IDE);
+
+    // for write test
+    // let mut b = Buf::new();
+    // b.dev = 1;
+    // b.blockno = 1;
+    // b.flags |= BUF_FLAGS_DIRTY;
+    // let str = "foobar";
+    // let src = VirtAddr(str.as_ptr() as u32);
+    // let dst = VirtAddr(b.data.as_ptr() as u32);
+    // unsafe { util::memcpy(dst, src, str.len()) };
+    // ide_rw(&mut b);
+
+    // for read test
+    // check buf.data at the last of ide_intr
+    // let mut b = Buf::new();
+    // b.dev = 1;
+    // b.blockno = 1;
+    // println!("buf.data: {:p}", &b.data);
+    // ide_rw(&mut b);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,10 +18,12 @@
 pub mod console;
 
 mod allocator;
+mod buf;
 pub mod constants;
 mod elf;
 mod env;
 mod gdt;
+mod ide;
 mod kclock;
 mod kernel_lock;
 mod lapic;
@@ -92,6 +94,8 @@ pub fn lib_main() {
     }
 
     picirq::pic_init();
+
+    ide::ide_init();
 
     print!("H");
     println!("ello");

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -3,7 +3,7 @@ use crate::gdt::consts::*;
 use crate::gdt::TaskState;
 use crate::pmap::VirtAddr;
 use crate::{env, gdt, sched, x86};
-use crate::{lapic, mpconfig, syscall};
+use crate::{ide, lapic, mpconfig, syscall};
 use consts::*;
 use core::mem;
 use core::slice;
@@ -365,6 +365,9 @@ fn trap_dispatch(tf: &mut Trapframe) {
     if tf.tf_trapno == (IRQ_OFFSET + IRQ_TIMER) as u32 {
         lapic::eoi();
         sched::sched_yield();
+    } else if tf.tf_trapno == (IRQ_OFFSET + IRQ_IDE) as u32 {
+        lapic::eoi();
+        ide::ide_intr();
     } else if tf.tf_trapno == T_SYSCALL {
         unsafe {
             let ret = syscall::syscall(

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -11,10 +11,44 @@ pub(crate) fn inb(port: u16) -> u8 {
 }
 
 #[inline]
+pub(crate) fn insl(port: u16, addr: *mut u32, cnt: usize) {
+    unsafe {
+        asm!("cld; rep insl" : :
+        "N{dx}" (port), "{esi}" (addr), "{ecx}" (cnt) :
+        "memory", "cc" :
+        "volatile");
+    }
+
+    // original in xv6
+    // constraint D is di register
+    // asm volatile("cld; rep insl" :
+    //              "=D" (addr), "=c" (cnt) :
+    //              "d" (port), "0" (addr), "1" (cnt) :
+    //              "memory", "cc");
+}
+
+#[inline]
 pub(crate) fn outb(port: u16, value: u8) {
     unsafe {
         asm!("outb $1, $0" :: "N{dx}"(port), "{al}"(value) :: "volatile");
     }
+}
+
+#[inline]
+pub(crate) fn outsl(port: u16, addr: *const u32, cnt: usize) {
+    unsafe {
+        asm!("cld; rep outsl" : :
+        "N{dx}" (port), "{esi}" (addr), "{ecx}" (cnt) :
+        "cc" :
+        "volatile");
+    }
+
+    // original in xv6
+    // constraint S is si register
+    // asm volatile("cld; rep outsl" :
+    //              "=S" (addr), "=c" (cnt) :
+    //              "d" (port), "0" (addr), "1" (cnt) :
+    //              "cc");
 }
 
 #[inline]
@@ -97,4 +131,14 @@ pub(crate) fn xchg<T>(p: *mut T, v: T) -> T {
     // let res: u32;
     // unsafe { asm!("lock; xchgl $0, $1" : "+m"(*p), "=a"(res) : "1"(v) : "cc" : "volatile") }
     // res
+}
+
+#[inline]
+pub(crate) fn cli() {
+    unsafe { asm!("cli" :::: "volatile") };
+}
+
+#[inline]
+pub(crate) fn sti() {
+    unsafe { asm!("sti" :::: "volatile") };
 }


### PR DESCRIPTION
Implement IDE operations (sending and receiving from I/O port for IDE).
The implementation is mainly based on `ide.c` in xv6 or JOS.