### PR TITLE
Disable IDE interrupt and r/w disk by polling

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -20,7 +20,6 @@ pub(crate) struct Buf {
     pub(crate) blockno: u32,
     // lock: SleepLock,
     pub(crate) refcnt: u32,
-    pub(crate) qnext: *mut Buf, // disk queue
     pub(crate) data: [u8; BLK_SIZE],
 }
 
@@ -31,7 +30,6 @@ impl Buf {
             dev: 0,
             blockno: 0,
             refcnt: 0,
-            qnext: null_mut(),
             data: [0; BLK_SIZE],
         }
     }

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -365,11 +365,7 @@ fn trap_dispatch(tf: &mut Trapframe) {
     if tf.tf_trapno == (IRQ_OFFSET + IRQ_TIMER) as u32 {
         lapic::eoi();
     } else if tf.tf_trapno == (IRQ_OFFSET + IRQ_IDE) as u32 {
-        // Don't send EOI to lapic because interrupt comes from 8259A.
-        // AEOI mode is enabled (see picirq.rs), so manual EOI is not also necessary for 8259A.
-        // lapic::eoi();
-
-        ide::ide_intr();
+        panic!("unexpected interrupt from IDE");
     } else if tf.tf_trapno == T_SYSCALL {
         unsafe {
             let ret = syscall::syscall(


### PR DESCRIPTION
The current design around lock and interrupt is a little messy, so I decided to disable interrupt in kernel at all. This pull request disables IDE interrupt and r/w disk by polling.