### PR TITLE
Fix memory leak when exec

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -368,20 +368,8 @@ impl EnvTable {
             println!("[{:08x}] free env {:08x}", curenv_id, env.env_id);
         }
 
-        // Flush all mapped pages in the user portion of the address space
-        assert_eq!(UTOP % (PTSIZE as u32), 0);
-        let start_pdx = PDX::new(VirtAddr(0));
-        let end_pdx = PDX::new(VirtAddr(UTOP));
-        let mut pdx = start_pdx;
-        while pdx < end_pdx {
-            let pde = &env.env_pgdir[pdx];
-            // only look at mapped page tables
-            if pde.exists() {
-                // unmap all PTEs in this page table
-                env.env_pgdir.remove_pde(pdx);
-            }
-            pdx += 1;
-        }
+        // Flush all mapped pages in the user portion of the address space.
+        // This is handled by Drop trait of PageDirectory, so do nothing here.
 
         // free the page directory
         // The allocation of pgdir is currently managed by rust,

--- a/src/pmap.rs
+++ b/src/pmap.rs
@@ -820,7 +820,6 @@ pub fn mem_init() {
     let mut allocator = PAGE_ALLOCATOR.lock();
     allocator.init(pages, &mut boot_allocator, npages, npages_basemem);
     println!("pages: 0x{:?}", pages);
-
     println!("page_free_list: 0x{:?}", allocator.page_free_list);
 
     // Now we set up virtual memory
@@ -1015,6 +1014,14 @@ impl PageAllocator {
                 _ => {}
             }
 
+            #[cfg(feature = "debug")]
+            println!(
+                "[PageAllocator] alloc. pp: {:p}, phys: {:x}, page_free_list: {:p}",
+                pp,
+                self.to_pa(pp).0,
+                self.page_free_list
+            );
+
             (*pp).pp_ref = 0;
             (*pp).pp_link = null_mut();
 
@@ -1067,9 +1074,23 @@ impl PageAllocator {
             assert_ne!(pp, null_mut(), "pp should not be null");
             assert_eq!((*pp).pp_ref, 0, "pp_ref should be zero");
             assert_eq!((*pp).pp_link, null_mut(), "pp_link should be null");
+
+            #[cfg(feature = "debug")]
+            println!("[PageAllocator] free page_info {:p} ", pp);
             (*pp).pp_link = self.page_free_list;
             self.page_free_list = pp;
         }
+    }
+
+    /// Return count of free pages.
+    pub(crate) fn count(&self) -> usize {
+        let mut n = 0;
+        let mut ptr = self.page_free_list;
+        while ptr != null_mut() {
+            n += 1;
+            ptr = unsafe { (*ptr).pp_link };
+        }
+        n
     }
 }
 
@@ -1081,4 +1102,9 @@ pub(crate) fn percpu_kstacks() -> &'static [CpuStack] {
 pub(crate) fn load_kern_pgdir() {
     let kern_pgdir = KERN_PGDIR.lock();
     x86::lcr3(kern_pgdir.paddr());
+}
+
+pub(crate) fn free_page_count() -> usize {
+    let allocator = PAGE_ALLOCATOR.lock();
+    allocator.count()
 }

--- a/src/syscall.rs
+++ b/src/syscall.rs
@@ -5,7 +5,7 @@ use crate::env::EnvId;
 use crate::file::FileDescriptor;
 use crate::fs::Stat;
 use crate::pmap::VirtAddr;
-use crate::{env, sysfile};
+use crate::{env, pmap, sysfile};
 use crate::{sched, util};
 use alloc::vec::Vec;
 use consts::*;
@@ -121,6 +121,8 @@ pub(crate) unsafe fn syscall(syscall_no: u32, a1: u32, a2: u32, a3: u32, a4: u32
         let env_id = sys_get_env_id();
         env_id.0 as i32
     } else if syscall_no == SYS_FORK {
+        #[cfg(feature = "debug")]
+        println!("free_page_count before fork: {}", pmap::free_page_count());
         let env_id = sys_fork();
         env_id.0 as i32
     } else if syscall_no == SYS_KILL {
@@ -129,6 +131,8 @@ pub(crate) unsafe fn syscall(syscall_no: u32, a1: u32, a2: u32, a3: u32, a4: u32
         env::env_destroy(env_id, env_table);
         0
     } else if syscall_no == SYS_EXEC {
+        #[cfg(feature = "debug")]
+        println!("free_page_count before fork: {}", pmap::free_page_count());
         let path = a1 as *const u8;
         path_check(path);
         let arg_arr = [


### PR DESCRIPTION
PageAllocator で物理ページの割当を管理しているが、その挙動をログで確認していると、コマンド実行後に free すべきページが割り当てられたまま返ってきていなかった。

調べた結果、env.rs の exec メソッドで env_pgdir を新しいのに切り替えているけど、古い pgdir に割り当てられたページの後処理を忘れている。なので fork, exec したときに fork 時に割り当てたページが解放されずにメモリリークが発生している。

https://github.com/tiqwab/xv6-rust/blob/d3b5de98347d577668752eb95f4c40eee525db71/src/env.rs#L619-L622

古い pgdir に割り当てられたページの解放は env.rs の env_free メソッドで行っていたが、PageDirectory の Drop trait で実装する方が解放忘れの心配もなくわかりやすそうなのでそちらに処理を移動した。