### PR TITLE
Handle exec with illegal command

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -687,7 +687,8 @@ pub(crate) fn exec(path: *const u8, argv: &[*const u8], env: &mut Env) {
         for (i, s) in argv.iter().enumerate() {
             let len = util::strnlen(*s, MAX_CMD_ARG_LEN);
             sp = sp.sub(len + 1);
-            util::strncpy(sp, *s, len + 1);
+            util::strncpy(sp, *s, len);
+            *(sp.add(len)) = b'\0';
             ustack[3 + i] = sp as u32;
         }
         sp = sp.sub(mem::size_of_val(&ustack));

--- a/src/sysfile.rs
+++ b/src/sysfile.rs
@@ -382,9 +382,8 @@ pub(crate) fn exec(orig_path: *const u8, orig_argv: &[*const u8]) -> Result<(), 
             argv[i] = argv_stack[i].as_ptr() as *const u8;
         }
 
-        env::exec(path.as_ptr(), &argv[0..orig_argv.len()], env);
+        env::exec(path.as_ptr(), &argv[0..orig_argv.len()], env)
     }
-    Ok(())
 }
 
 /// Return the length of name (exclusive '\0' at the end)

--- a/user/ls.c
+++ b/user/ls.c
@@ -46,7 +46,7 @@ void ls(char *path) {
                 break;
             }
             strcpy(buf, path);
-            p = buf + strlen(buf);
+            p = buf + strlen(path);
             *p++ = '/';
 
             sz = 0;
@@ -56,8 +56,8 @@ void ls(char *path) {
                 if (de.inum == 0) {
                     continue;
                 }
-                memmove(p, de.name, DIR_SIZ);
-                p[DIR_SIZ] = 0;
+                strcpy(p, de.name);
+                *(p + strlen(de.name)) = 0;
                 if (stat(buf, &st) < 0) {
                     printf("ls: cannot stat %s\n", buf);
                     continue;


### PR DESCRIPTION
Executing an illegal command caused panic before, so fix it.

```
$ illegal
sh: exec /illegal failed
$
```